### PR TITLE
feat: impl median delta applier

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,5 @@ LOG_LEVEL=debug
 VALUE_PROVIDER_CLIENT_PORT=3101
 # Set to "fixed" to use a fixed provider, leave empty for ccxt provider
 VALUE_PROVIDER_IMPL="fixed"
+# Set true to enable feed calibration
+FEED_CALIBRATION_ENABLED=true

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,9 +1,11 @@
-import { Body, Controller, Param, ParseIntPipe, Post, Inject, Logger } from "@nestjs/common";
+import { Body, Controller, Param, ParseIntPipe, Post, Inject, Logger, UseInterceptors } from "@nestjs/common";
 import { ApiTags } from "@nestjs/swagger";
 import { ExampleProviderService } from "./app.service";
 import { FeedValuesRequest, FeedValuesResponse, RoundFeedValuesResponse } from "./dto/provider-requests.dto";
+import { FeedCalibrationInterceptor } from "./median/interceptors/feed-calibration.interceptor";
 
 @ApiTags("Feed Value Provider API")
+@UseInterceptors(FeedCalibrationInterceptor)
 @Controller()
 export class ExampleProviderController {
   private logger = new Logger(ExampleProviderController.name);

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,13 +1,14 @@
-import { Module } from "@nestjs/common";
+import { forwardRef, Module } from "@nestjs/common";
 import { ExampleProviderService } from "./app.service";
 import { ExampleProviderController } from "./app.controller";
 import { CcxtFeed } from "./data-feeds/ccxt-provider-service";
 import { RandomFeed } from "./data-feeds/random-feed";
 import { BaseDataFeed } from "./data-feeds/base-feed";
 import { FixedFeed } from "./data-feeds/fixed-feed";
+import { MedianModule } from "./median/median.module";
 
 @Module({
-  imports: [],
+  imports: [forwardRef(() => MedianModule)],
   controllers: [ExampleProviderController],
   providers: [
     {
@@ -30,5 +31,6 @@ import { FixedFeed } from "./data-feeds/fixed-feed";
       },
     },
   ],
+  exports: ["EXAMPLE_PROVIDER_SERVICE"],
 })
 export class RandomExampleProviderModule {}

--- a/src/config/feeds.json
+++ b/src/config/feeds.json
@@ -565,6 +565,10 @@
       {
         "exchange": "cryptocom",
         "symbol": "USDT/USD"
+      },
+      {
+        "exchange": "kraken",
+        "symbol": "USDT/USD"
       }
     ]
   },

--- a/src/config/feeds.json
+++ b/src/config/feeds.json
@@ -17,6 +17,22 @@
       {
         "exchange": "okx",
         "symbol": "FLR/USDT"
+      },
+      {
+        "exchange": "coinbase",
+        "symbol": "FLR/USD"
+      },
+      {
+        "exchange": "kraken",
+        "symbol": "FLR/USD"
+      },
+      {
+        "exchange": "bybit",
+        "symbol": "FLR/USDT"
+      },
+      {
+        "exchange": "htx",
+        "symbol": "FLR/USDT"
       }
     ]
   },
@@ -34,6 +50,10 @@
       {
         "exchange": "kraken",
         "symbol": "SGB/USD"
+      },
+      {
+        "exchange": "mexc",
+        "symbol": "SGB/USDT"
       }
     ]
   },
@@ -67,6 +87,18 @@
       {
         "exchange": "binance",
         "symbol": "XRP/USDT"
+      },
+      {
+        "exchange": "coinbase",
+        "symbol": "XRP/USD"
+      },
+      {
+        "exchange": "bybit",
+        "symbol": "XRP/USDT"
+      },
+      {
+        "exchange": "kraken",
+        "symbol": "XRP/USD"
       }
     ]
   },
@@ -209,6 +241,10 @@
       {
         "exchange": "okx",
         "symbol": "ADA/USDT"
+      },
+      {
+        "exchange": "coinbase",
+        "symbol": "ADA/USD"
       }
     ]
   },
@@ -862,6 +898,14 @@
       {
         "exchange": "okx",
         "symbol": "UNI/USDT"
+      },
+      {
+        "exchange": "htx",
+        "symbol": "UNI/USDT"
+      },
+      {
+        "exchange": "coinbase",
+        "symbol": "UNI/USD"
       }
     ]
   },
@@ -1362,7 +1406,11 @@
     "feed": { "category": 1, "name": "SUI/USD" },
     "sources": [
       {
-        "exchange": "ascendex",
+        "exchange": "coinbase",
+        "symbol": "SUI/USD"
+      },
+      {
+        "exchange": "okx",
         "symbol": "SUI/USDT"
       },
       {
@@ -1371,10 +1419,6 @@
       },
       {
         "exchange": "bingx",
-        "symbol": "SUI/USDT"
-      },
-      {
-        "exchange": "bitfinex2",
         "symbol": "SUI/USDT"
       },
       {
@@ -1387,6 +1431,14 @@
       },
       {
         "exchange": "bybit",
+        "symbol": "SUI/USDT"
+      },
+      {
+        "exchange": "okx",
+        "symbol": "SUI/USDT"
+      },
+      {
+        "exchange": "mexc",
         "symbol": "SUI/USDT"
       }
     ]
@@ -1403,10 +1455,6 @@
         "symbol": "PEPE/USDT"
       },
       {
-        "exchange": "bitfinex2",
-        "symbol": "PEPE/USDT"
-      },
-      {
         "exchange": "bitget",
         "symbol": "PEPE/USDT"
       },
@@ -1420,6 +1468,22 @@
       },
       {
         "exchange": "cryptocom",
+        "symbol": "PEPE/USDT"
+      },
+      {
+        "exchange": "coinbase",
+        "symbol": "PEPE/USD"
+      },
+      {
+        "exchange": "gate",
+        "symbol": "PEPE/USDT"
+      },
+      {
+        "exchange": "okx",
+        "symbol": "PEPE/USDT"
+      },
+      {
+        "exchange": "htx",
         "symbol": "PEPE/USDT"
       }
     ]
@@ -1457,10 +1521,6 @@
     "feed": { "category": 1, "name": "AAVE/USD" },
     "sources": [
       {
-        "exchange": "ascendex",
-        "symbol": "AAVE/USDT"
-      },
-      {
         "exchange": "binanceus",
         "symbol": "AAVE/USDT"
       },
@@ -1469,20 +1529,28 @@
         "symbol": "AAVE/USDT"
       },
       {
-        "exchange": "bitfinex2",
-        "symbol": "AAVE/USDT"
-      },
-      {
         "exchange": "bitget",
-        "symbol": "AAVE/USDT"
-      },
-      {
-        "exchange": "bitmart",
         "symbol": "AAVE/USDT"
       },
       {
         "exchange": "bybit",
         "symbol": "AAVE/USDT"
+      },
+      {
+        "exchange": "htx",
+        "symbol": "AAVE/USDT"
+      },
+      {
+        "exchange": "gate",
+        "symbol": "AAVE/USDT"
+      },
+      {
+        "exchange": "okx",
+        "symbol": "AAVE/USDT"
+      },
+      {
+        "exchange": "coinbase",
+        "symbol": "AAVE/USD"
       }
     ]
   },
@@ -1490,19 +1558,11 @@
     "feed": { "category": 1, "name": "FTM/USD" },
     "sources": [
       {
-        "exchange": "ascendex",
-        "symbol": "FTM/USDT"
-      },
-      {
         "exchange": "binanceus",
         "symbol": "FTM/USDT"
       },
       {
         "exchange": "bingx",
-        "symbol": "FTM/USDT"
-      },
-      {
-        "exchange": "bitfinex2",
         "symbol": "FTM/USDT"
       },
       {
@@ -1515,6 +1575,18 @@
       },
       {
         "exchange": "bybit",
+        "symbol": "FTM/USDT"
+      },
+      {
+        "exchange": "kucoin",
+        "symbol": "FTM/USDT"
+      },
+      {
+        "exchange": "okx",
+        "symbol": "FTM/USDT"
+      },
+      {
+        "exchange": "gate",
         "symbol": "FTM/USDT"
       }
     ]

--- a/src/config/feeds.json
+++ b/src/config/feeds.json
@@ -439,14 +439,6 @@
         "symbol": "MATIC/USDT"
       },
       {
-        "exchange": "cryptocom",
-        "symbol": "MATIC/USDT"
-      },
-      {
-        "exchange": "cryptocom",
-        "symbol": "MATIC/USD"
-      },
-      {
         "exchange": "gate",
         "symbol": "MATIC/USDT"
       },

--- a/src/config/feeds.json
+++ b/src/config/feeds.json
@@ -1729,5 +1729,14 @@
         "symbol": "JOULE/USDT"
       }
     ]
+  },
+  {
+    "feed": { "category": 1, "name": "USDX/USD" },
+    "sources": [
+      {
+        "exchange": "bitmart",
+        "symbol": "USDX/USDT"
+      }
+    ]
   }
 ]

--- a/src/config/feeds.json
+++ b/src/config/feeds.json
@@ -17,22 +17,6 @@
       {
         "exchange": "okx",
         "symbol": "FLR/USDT"
-      },
-      {
-        "exchange": "coinbase",
-        "symbol": "FLR/USD"
-      },
-      {
-        "exchange": "kraken",
-        "symbol": "FLR/USD"
-      },
-      {
-        "exchange": "bybit",
-        "symbol": "FLR/USDT"
-      },
-      {
-        "exchange": "htx",
-        "symbol": "FLR/USDT"
       }
     ]
   },
@@ -50,10 +34,6 @@
       {
         "exchange": "kraken",
         "symbol": "SGB/USD"
-      },
-      {
-        "exchange": "mexc",
-        "symbol": "SGB/USDT"
       }
     ]
   },
@@ -87,18 +67,6 @@
       {
         "exchange": "binance",
         "symbol": "XRP/USDT"
-      },
-      {
-        "exchange": "coinbase",
-        "symbol": "XRP/USD"
-      },
-      {
-        "exchange": "bybit",
-        "symbol": "XRP/USDT"
-      },
-      {
-        "exchange": "kraken",
-        "symbol": "XRP/USD"
       }
     ]
   },
@@ -241,10 +209,6 @@
       {
         "exchange": "okx",
         "symbol": "ADA/USDT"
-      },
-      {
-        "exchange": "coinbase",
-        "symbol": "ADA/USD"
       }
     ]
   },
@@ -517,7 +481,7 @@
       },
       {
         "exchange": "okx",
-        "symbol": "POL/USDC"
+        "symbol": "POL/USDT"
       },
       {
         "exchange": "binance",
@@ -600,10 +564,6 @@
       },
       {
         "exchange": "cryptocom",
-        "symbol": "USDT/USD"
-      },
-      {
-        "exchange": "kraken",
         "symbol": "USDT/USD"
       }
     ]
@@ -898,14 +858,6 @@
       {
         "exchange": "okx",
         "symbol": "UNI/USDT"
-      },
-      {
-        "exchange": "htx",
-        "symbol": "UNI/USDT"
-      },
-      {
-        "exchange": "coinbase",
-        "symbol": "UNI/USD"
       }
     ]
   },
@@ -1406,11 +1358,7 @@
     "feed": { "category": 1, "name": "SUI/USD" },
     "sources": [
       {
-        "exchange": "coinbase",
-        "symbol": "SUI/USD"
-      },
-      {
-        "exchange": "okx",
+        "exchange": "ascendex",
         "symbol": "SUI/USDT"
       },
       {
@@ -1419,6 +1367,10 @@
       },
       {
         "exchange": "bingx",
+        "symbol": "SUI/USDT"
+      },
+      {
+        "exchange": "bitfinex2",
         "symbol": "SUI/USDT"
       },
       {
@@ -1431,14 +1383,6 @@
       },
       {
         "exchange": "bybit",
-        "symbol": "SUI/USDT"
-      },
-      {
-        "exchange": "okx",
-        "symbol": "SUI/USDT"
-      },
-      {
-        "exchange": "mexc",
         "symbol": "SUI/USDT"
       }
     ]
@@ -1455,6 +1399,10 @@
         "symbol": "PEPE/USDT"
       },
       {
+        "exchange": "bitfinex2",
+        "symbol": "PEPE/USDT"
+      },
+      {
         "exchange": "bitget",
         "symbol": "PEPE/USDT"
       },
@@ -1468,22 +1416,6 @@
       },
       {
         "exchange": "cryptocom",
-        "symbol": "PEPE/USDT"
-      },
-      {
-        "exchange": "coinbase",
-        "symbol": "PEPE/USD"
-      },
-      {
-        "exchange": "gate",
-        "symbol": "PEPE/USDT"
-      },
-      {
-        "exchange": "okx",
-        "symbol": "PEPE/USDT"
-      },
-      {
-        "exchange": "htx",
         "symbol": "PEPE/USDT"
       }
     ]
@@ -1521,11 +1453,19 @@
     "feed": { "category": 1, "name": "AAVE/USD" },
     "sources": [
       {
+        "exchange": "ascendex",
+        "symbol": "AAVE/USDT"
+      },
+      {
         "exchange": "binanceus",
         "symbol": "AAVE/USDT"
       },
       {
         "exchange": "bingx",
+        "symbol": "AAVE/USDT"
+      },
+      {
+        "exchange": "bitfinex2",
         "symbol": "AAVE/USDT"
       },
       {
@@ -1533,24 +1473,12 @@
         "symbol": "AAVE/USDT"
       },
       {
+        "exchange": "bitmart",
+        "symbol": "AAVE/USDT"
+      },
+      {
         "exchange": "bybit",
         "symbol": "AAVE/USDT"
-      },
-      {
-        "exchange": "htx",
-        "symbol": "AAVE/USDT"
-      },
-      {
-        "exchange": "gate",
-        "symbol": "AAVE/USDT"
-      },
-      {
-        "exchange": "okx",
-        "symbol": "AAVE/USDT"
-      },
-      {
-        "exchange": "coinbase",
-        "symbol": "AAVE/USD"
       }
     ]
   },
@@ -1558,11 +1486,19 @@
     "feed": { "category": 1, "name": "FTM/USD" },
     "sources": [
       {
+        "exchange": "ascendex",
+        "symbol": "FTM/USDT"
+      },
+      {
         "exchange": "binanceus",
         "symbol": "FTM/USDT"
       },
       {
         "exchange": "bingx",
+        "symbol": "FTM/USDT"
+      },
+      {
+        "exchange": "bitfinex2",
         "symbol": "FTM/USDT"
       },
       {
@@ -1575,18 +1511,6 @@
       },
       {
         "exchange": "bybit",
-        "symbol": "FTM/USDT"
-      },
-      {
-        "exchange": "kucoin",
-        "symbol": "FTM/USDT"
-      },
-      {
-        "exchange": "okx",
-        "symbol": "FTM/USDT"
-      },
-      {
-        "exchange": "gate",
         "symbol": "FTM/USDT"
       }
     ]

--- a/src/config/feeds.json
+++ b/src/config/feeds.json
@@ -517,7 +517,7 @@
       },
       {
         "exchange": "okx",
-        "symbol": "POL/USDT"
+        "symbol": "POL/USDC"
       },
       {
         "exchange": "binance",

--- a/src/config/feeds.json
+++ b/src/config/feeds.json
@@ -437,18 +437,6 @@
       {
         "exchange": "binance",
         "symbol": "MATIC/USDT"
-      },
-      {
-        "exchange": "gate",
-        "symbol": "MATIC/USDT"
-      },
-      {
-        "exchange": "kucoin",
-        "symbol": "MATIC/USDT"
-      },
-      {
-        "exchange": "okx",
-        "symbol": "MATIC/USDT"
       }
     ]
   },

--- a/src/data-feeds/ccxt-provider-service.ts
+++ b/src/data-feeds/ccxt-provider-service.ts
@@ -200,8 +200,12 @@ export class CcxtFeed implements BaseDataFeed {
 
     // If no valid prices were found, return undefined
     if (prices.length === 0) {
-      this.logger.warn(`Unable to calculate median for ${JSON.stringify(feedId)}`);
+      this.logger.warn(`No prices found for ${JSON.stringify(feedId)}`);
       return undefined;
+    }
+    // If single price found, return price
+    if (prices.length === 1) {
+      return prices[0];
     }
 
     // Sort the prices in ascending order

--- a/src/data-feeds/ccxt-provider-service.ts
+++ b/src/data-feeds/ccxt-provider-service.ts
@@ -1,5 +1,5 @@
 import { Logger } from "@nestjs/common";
-import ccxt, { Exchange, Trade } from "ccxt";
+import ccxt, { Exchange, pro, Trade } from "ccxt";
 import { readFileSync } from "fs";
 import { FeedId, FeedValueData } from "../dto/provider-requests.dto";
 import { BaseDataFeed } from "./base-feed";
@@ -27,12 +27,13 @@ interface FeedConfig {
 }
 
 interface PriceInfo {
-  price: number;
+  value: number;
   time: number;
   exchange: string;
 }
 
 const usdtToUsdFeedId: FeedId = { category: FeedCategory.Crypto.valueOf(), name: "USDT/USD" };
+const lambda = process.env.MEDIAN_DECAY ? parseFloat(process.env.MEDIAN_DECAY) : undefined;
 
 export class CcxtFeed implements BaseDataFeed {
   private readonly logger = new Logger(CcxtFeed.name);
@@ -202,7 +203,7 @@ export class CcxtFeed implements BaseDataFeed {
   private setPrice(exchangeName: string, symbol: string, price: number, timestamp: number) {
     const prices = this.prices.get(symbol) || new Map<string, PriceInfo>();
     prices.set(exchangeName, {
-      price: price,
+      value: price,
       time: timestamp,
       exchange: exchangeName,
     });
@@ -227,7 +228,7 @@ export class CcxtFeed implements BaseDataFeed {
       return price * usdtToUsd;
     };
 
-    const prices: number[] = [];
+    const prices: PriceInfo[] = [];
 
     // Gather all available prices
     for (const source of config.sources) {
@@ -235,13 +236,16 @@ export class CcxtFeed implements BaseDataFeed {
       // Skip if no price information is available
       if (!info) continue;
 
-      let price = info.price;
+      let price = info.value;
 
       price = source.symbol.endsWith("USDT") ? await convertToUsd(source.symbol, source.exchange, price) : price;
       if (price === undefined) continue;
 
       // Add the price to our list for median calculation
-      prices.push(price);
+      prices.push({
+        ...info,
+        value: price,
+      });
     }
 
     if (prices.length === 0) {
@@ -249,22 +253,72 @@ export class CcxtFeed implements BaseDataFeed {
       return undefined;
     }
 
+    if (lambda === undefined) {
+      return this.median(prices);
+    } else {
+      return this.weightedMedian(prices);
+    }
+  }
+
+  private median(prices: PriceInfo[]): number {
     // If single price found, return price
     if (prices.length === 1) {
-      return prices[0];
+      return prices[0].value;
     }
 
     // Sort the prices in ascending order
-    prices.sort((a, b) => a - b);
+    prices.sort((a, b) => a.value - b.value);
 
     // Calculate the median
     const mid = Math.floor(prices.length / 2);
     const median =
       prices.length % 2 !== 0
-        ? prices[mid] // Odd number of elements, take the middle one
-        : (prices[mid - 1] + prices[mid]) / 2; // Even number of elements, average the two middle ones
+        ? prices[mid].value // Odd number of elements, take the middle one
+        : (prices[mid - 1].value + prices[mid].value) / 2; // Even number of elements, average the two middle ones
 
     return median;
+  }
+
+  private weightedMedian(prices: PriceInfo[]): number {
+    if (prices.length === 0) {
+      throw new Error("Price list cannot be empty.");
+    }
+
+    prices.sort((a, b) => a.time - b.time);
+
+    // Current time for weight calculation
+    const now = Date.now();
+
+    // Calculate exponential weights
+    const weights = prices.map(data => {
+      const timeDifference = now - data.time;
+      return Math.exp(-lambda * timeDifference); // Exponential decay
+    });
+
+    // Normalize weights to sum to 1
+    const weightSum = weights.reduce((sum, weight) => sum + weight, 0);
+    const normalizedWeights = weights.map(weight => weight / weightSum);
+
+    // Combine prices and weights
+    const weightedPrices = prices.map((data, i) => ({
+      price: data.value,
+      weight: normalizedWeights[i],
+    }));
+
+    // Sort prices by value for median calculation
+    weightedPrices.sort((a, b) => a.price - b.price);
+
+    // Find the weighted median
+    let cumulativeWeight = 0;
+    for (let i = 0; i < weightedPrices.length; i++) {
+      cumulativeWeight += weightedPrices[i].weight;
+      if (cumulativeWeight >= 0.5) {
+        return weightedPrices[i].price;
+      }
+    }
+
+    this.logger.warn("Unable to calculate weighted median");
+    return undefined;
   }
 
   private loadConfig() {

--- a/src/median/interceptors/feed-calibration.interceptor.ts
+++ b/src/median/interceptors/feed-calibration.interceptor.ts
@@ -1,0 +1,35 @@
+import { CallHandler, ExecutionContext, Injectable, NestInterceptor } from "@nestjs/common";
+import { Observable } from "rxjs";
+import { map } from "rxjs/operators";
+import { MedianDeltaCalculatorService } from "../median-delta-calculator.service";
+import { FeedValueData } from "src/dto/provider-requests.dto";
+
+export interface Response<T> {
+  data: T;
+}
+
+interface FeedResponse {
+  data: FeedValueData[];
+}
+
+@Injectable()
+export class FeedCalibrationInterceptor<T extends FeedValueData[]> implements NestInterceptor<T, Response<T>> {
+  constructor(private readonly medianService: MedianDeltaCalculatorService) {}
+  intercept(context: ExecutionContext, next: CallHandler): Observable<Response<T>> {
+    const isEnabled = process.env.FEED_CALIBRATION_ENABLED === "true";
+    if (!isEnabled) {
+      return next.handle();
+    }
+
+    return next.handle().pipe(
+      map((res: FeedResponse) => {
+        if (Array.isArray(res.data)) {
+          res.data.forEach(feedValue => {
+            feedValue.value = feedValue.value + this.medianService.getCurrentDelta(feedValue.feed.name);
+          });
+        }
+        return { data: res.data as T };
+      })
+    );
+  }
+}

--- a/src/median/median-delta-calculator.service.ts
+++ b/src/median/median-delta-calculator.service.ts
@@ -1,0 +1,261 @@
+import { Inject, Injectable, Logger, OnModuleInit } from "@nestjs/common";
+import { readFileSync } from "fs";
+import { ExampleProviderService } from "src/app.service";
+import { FeedValueData } from "src/dto/provider-requests.dto";
+import { sleepFor } from "src/utils/retry";
+
+const CONFIG_PREFIX = "src/config/";
+
+@Injectable()
+export class MedianDeltaCalculatorService implements OnModuleInit {
+  private readonly logger = new Logger(MedianDeltaCalculatorService.name);
+  private readonly baseVotingEpochTs = 1658430000; // 2022-11-21T00:00:00Z in Unix timestamp
+  private readonly votingEpochInterval = 90;
+  private readonly votingEpochSnapshotOffset = 15; // Save feed values on -15 seconds of the voting epoch
+  private readonly deltaCalculationTimeout = 5;
+  private readonly feedApiUrl = "https://flare-systems-explorer.flare.network/backend-url/api/v0/";
+
+  private readonly feedItems: JsonFeedItem[] = [];
+  private readonly deltaByName: Map<string, number> = new Map();
+  private readonly submittedFeedValues: Map<number, FeedValueData[]> = new Map();
+
+  constructor(
+    @Inject("EXAMPLE_PROVIDER_SERVICE")
+    private readonly exampleProviderService: ExampleProviderService
+  ) {
+    // Initialize the delta map with 0 for each feed
+    this.feedItems = this.loadConfig();
+
+    this.feedItems.forEach(item => {
+      this.deltaByName.set(item.feed.name, 0);
+    });
+  }
+
+  async onModuleInit() {
+    void this.start();
+  }
+
+  async start() {
+    this.logger.log("Starting median delta calculator service");
+
+    void this.startMedianPolling();
+    void this.startSnapshotLoop();
+  }
+
+  // 1. Fetch median feed values of the feed values saved on the previous step
+  // 2. Calculate the median delta of each feed
+  async startMedianPolling() {
+    this.logger.log("Median Polling | Starting polling for median delta calculation");
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      // Calculate the delay to the next voting epoch. Aim to save feed values on -15 seconds of the voting epoch
+      const elapsed = this.secondsSinceMidnight();
+      const delay =
+        this.votingEpochInterval -
+        (elapsed % this.votingEpochInterval) -
+        this.votingEpochSnapshotOffset -
+        this.deltaCalculationTimeout;
+      const adjustedDelay = delay <= 0 ? delay + this.votingEpochInterval : delay;
+
+      // Wait for the next voting epoch
+      this.logger.log(`Median Polling | Waiting ${adjustedDelay} seconds before starting polling...`);
+      await sleepFor(adjustedDelay * 1000);
+
+      const prevVotingEpochId = this.getCurrentVotingEpochId() - 1;
+
+      if (!this.submittedFeedValues[prevVotingEpochId]) {
+        this.logger.log(
+          `Median Polling | Last submitted feed values for ${prevVotingEpochId} not found. Skipping this round...`
+        );
+        continue;
+      }
+
+      const cachedLastSubmittedFeedValues = this.submittedFeedValues[prevVotingEpochId];
+
+      try {
+        // 1. Calculate delta from the last submitted feed values (if exists)
+        const { fromTs, toTs } = this.getVotingEpochRange(prevVotingEpochId);
+
+        // Fetch data for all feeds in parallel
+        const apiPromises = this.feedItems.map(feed =>
+          this.fetchFtsoFeed(feed.feed.name, fromTs, toTs, prevVotingEpochId)
+        );
+        const apiResults = await Promise.all(apiPromises);
+        const filteredApiResults = apiResults.filter(item => item);
+
+        if (filteredApiResults.length === 0) {
+          this.logger.error(`Median Polling | No data found for any feed in voting epoch ${prevVotingEpochId}`);
+          continue;
+        }
+
+        // 2. Update delta map
+        apiResults.forEach(feed => {
+          if (!feed) return;
+
+          const lastSubmittedFeed = cachedLastSubmittedFeedValues.find(item => item.feed.name === feed.name);
+          if (!lastSubmittedFeed) {
+            this.logger.warn(`Median Polling | No last submitted feed found for ${feed.name}`);
+            return;
+          }
+
+          const delta = feed.median - lastSubmittedFeed.value;
+          this.deltaByName.set(feed.name, delta);
+        });
+
+        this.logger.log(
+          `Median Polling | Fetched delta values of previous voting epoch ${prevVotingEpochId} successfully`
+        );
+      } catch (e) {
+        this.logger.error(`${e}`);
+        await sleepFor(10_000);
+      }
+
+      // Wait for the next voting epoch
+      this.logger.log(`Waiting ${adjustedDelay} seconds before starting polling...`);
+      await sleepFor(adjustedDelay * 1000);
+    }
+  }
+
+  // 1. Save local feed values on every -15 seconds of the voting epoch
+  async startSnapshotLoop() {
+    this.logger.log("Snapshot Loop | Starting current feed values snapshot loop");
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      // Calculate the delay to the next voting epoch. Aim to save feed values on -15 seconds of the voting epoch
+      const elapsed = this.secondsSinceMidnight();
+      const delay = this.votingEpochInterval - (elapsed % this.votingEpochInterval) - this.votingEpochSnapshotOffset;
+      const adjustedDelay = delay <= 0 ? delay + this.votingEpochInterval : delay;
+
+      // Wait for the next voting epoch
+      this.logger.log(`Snapshot Loop | Waiting ${adjustedDelay} seconds before starting polling...`);
+      await sleepFor(adjustedDelay * 1000);
+
+      const targetVotingEpochId = this.getCurrentVotingEpochId() + 1;
+
+      try {
+        await this.updateLastSubmittedFeedValues(targetVotingEpochId);
+
+        this.logger.log(
+          `Snapshot Loop | Updated ${this.submittedFeedValues[targetVotingEpochId].length} last submitted feed values for voting epoch ${targetVotingEpochId}`
+        );
+      } catch (e) {
+        this.logger.error(`${e}`);
+        await sleepFor(10_000);
+      }
+    }
+  }
+
+  // Helper function to convert name to feed_name format
+  convertToFeedName(name: string): string {
+    const asciiHex = name
+      .split("")
+      .map(char => char.charCodeAt(0).toString(16).padStart(2, "0"))
+      .join("");
+
+    const baseFeedName = `01${asciiHex}`;
+    const totalLength = 42; // Desired length of the final feed_name
+    const paddingLength = totalLength - baseFeedName.length;
+
+    // Add the required padding
+    const paddedFeedName = baseFeedName + "0".repeat(Math.max(0, paddingLength));
+    return paddedFeedName;
+  }
+
+  // Fetch data for a single feed
+  async fetchFtsoFeed(
+    name: string,
+    fromTs: number,
+    toTs: number,
+    targetVotingRoundId: number
+  ): Promise<FeedResponseNormalized | undefined> {
+    const feedName = this.convertToFeedName(name);
+    const apiUrl = `${this.feedApiUrl}/ftso_feed?feed_name=${feedName}&from_ts=${fromTs}&to_ts=${toTs}&relative=false`;
+
+    try {
+      const response = await fetch(apiUrl);
+      if (!response.ok) throw new Error(`Error fetching data for ${name}: ${response.statusText}`);
+
+      const data: FtsoFeedResponse[] = await response.json();
+      if (!data.length) {
+        this.logger.warn(`No data found for ${name}`);
+        return;
+      }
+
+      const item = data.find(item => item.voting_round_id === targetVotingRoundId);
+      if (!item) {
+        this.logger.warn(`No data found for ${name} in voting round ${targetVotingRoundId}`);
+        return;
+      }
+
+      const [quartileLow, quartileHigh] = item.quartiles;
+      const [secondaryLow, secondaryHigh] = item.secondary_bands;
+
+      return {
+        name: name,
+        median: item.value,
+        primaryLow: quartileLow,
+        primaryHigh: quartileHigh,
+        secondaryLow,
+        secondaryHigh,
+      };
+    } catch (error) {
+      this.logger.error(`Error processing ${name}:`, error);
+      return;
+    }
+  }
+
+  async updateLastSubmittedFeedValues(currentVotingEpochId: number) {
+    const feedValues = await this.exampleProviderService.getValues(this.feedItems.map(item => item.feed));
+    this.submittedFeedValues[currentVotingEpochId] = feedValues;
+    this.submittedFeedValues.delete(currentVotingEpochId - 2);
+  }
+
+  // Helper function to calculate time range for a given voting epoch
+  getVotingEpochRange(votingEpochId: number) {
+    const fromTs = this.baseVotingEpochTs + votingEpochId * this.votingEpochInterval;
+    const toTs = fromTs + this.votingEpochInterval;
+    return { fromTs, toTs };
+  }
+
+  // Helper function to calculate the number of seconds since midnight
+  secondsSinceMidnight(): number {
+    const now = new Date();
+    return now.getSeconds() + now.getMinutes() * 60 + now.getHours() * 3600;
+  }
+
+  getCurrentVotingEpochId(): number {
+    const currentTs = Math.floor(Date.now() / 1000);
+    return Math.floor((currentTs - this.baseVotingEpochTs) / this.votingEpochInterval);
+  }
+
+  getCurrentDelta(name: string): number {
+    return this.deltaByName.get(name) ?? 0;
+  }
+
+  // use config of CcxtFeed
+  private loadConfig() {
+    const network = process.env.NETWORK as networks;
+    let configPath: string;
+    switch (network) {
+      case "local-test":
+        configPath = CONFIG_PREFIX + "test-feeds.json";
+        break;
+      default:
+        configPath = CONFIG_PREFIX + "feeds.json";
+    }
+
+    try {
+      const jsonString = readFileSync(configPath, "utf-8");
+      const config: JsonFeedItem[] = JSON.parse(jsonString);
+
+      this.logger.log(`Supported feeds: ${JSON.stringify(config.map(f => f.feed))}`);
+
+      return config;
+    } catch (err) {
+      this.logger.error("Error parsing JSON config:", err);
+      throw err;
+    }
+  }
+}

--- a/src/median/median.module.ts
+++ b/src/median/median.module.ts
@@ -1,0 +1,12 @@
+import { forwardRef, Module } from "@nestjs/common";
+import { MedianDeltaCalculatorService } from "./median-delta-calculator.service";
+import { APP_INTERCEPTOR } from "@nestjs/core";
+import { FeedCalibrationInterceptor } from "./interceptors/feed-calibration.interceptor";
+import { RandomExampleProviderModule } from "src/app.module";
+
+@Module({
+  imports: [forwardRef(() => RandomExampleProviderModule)],
+  providers: [MedianDeltaCalculatorService, { provide: APP_INTERCEPTOR, useClass: FeedCalibrationInterceptor }],
+  exports: [MedianDeltaCalculatorService],
+})
+export class MedianModule {}

--- a/src/median/types.d.ts
+++ b/src/median/types.d.ts
@@ -1,0 +1,32 @@
+type JsonFeedItem = {
+  feed: {
+    category: number;
+    name: string;
+  };
+  sources: {
+    exchange: string;
+    symbol: string;
+  }[];
+};
+
+type FtsoFeedResponse = {
+  feed: {
+    representation: string;
+    feed_name: string;
+  };
+  quartiles: number[];
+  secondary_bands: number[];
+  voting_round_id: number;
+  value: number;
+};
+
+type FeedResponseNormalized = {
+  name: string;
+  median: number;
+  primaryLow: number;
+  primaryHigh: number;
+  secondaryLow: number;
+  secondaryHigh: number;
+};
+
+type networks = "local-test" | "from-env" | "coston2" | "coston" | "songbird";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1689,9 +1689,9 @@ caniuse-lite@^1.0.30001587:
   integrity sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g==
 
 ccxt@^4.0.64:
-  version "4.3.55"
-  resolved "https://registry.yarnpkg.com/ccxt/-/ccxt-4.3.55.tgz#3887ea5c8905cf3ddf31314ffaea9d001cf655a6"
-  integrity sha512-WsogzkssYfYECmveCLaQ3ktWmCXo6KZj/e1cMpsguB46kp2SD8g0yqZ4uWw1tCdsVt/aw8hbGtPzs22K6AV+eg==
+  version "4.4.32"
+  resolved "https://registry.yarnpkg.com/ccxt/-/ccxt-4.4.32.tgz#b09debf33bccbec16709203a6cdb77a78611095f"
+  integrity sha512-bXmZ+VnE/xRr4CgpzRXIs3ENm5qQPRL5gBAY9gbRaSB+1RuaWmFawG/XyCO8h2tdQpdpmfBKu2zbJ1G60bW/Yg==
   dependencies:
     ws "^8.8.1"
 
@@ -5244,9 +5244,9 @@ write-file-atomic@^4.0.2:
     signal-exit "^3.0.7"
 
 ws@^8.8.1:
-  version "8.17.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
-  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
 xtend@^4.0.0:
   version "4.0.2"


### PR DESCRIPTION
## 목표
가격 정확도 30%를 넘겨 NO REWARDS 표시되지 않게 하는것

## 적용방법
env에 FEED_CALIBRATION_ENABLED=true 추가시 활성화 됨

## 주요 변경사항
- median 모듈을 추가하고, 이를 최상위 모듈에서 import하는 구조입니다
- `MedianDeltaCalculatorService`가 주기적으로 돌면서 FTSO v2 대시보드 API에서 이전 에폭의 median 값을 polling 한뒤, 당시 제출했던 가격과 비교하여 delta값을 뽑아냅니다
- `/feed-values` 요청이 들어오면 interceptor가 동작해 가격에 delta값을 적용한뒤 반환합니다

## 설계 의도
interceptor를 사용한 이유는 기반 구현체가 변경되어도 호환되게 하기 위함입니다. (기존 ccxt feed, 스노우 feed, coingecko feed 모두 적용 가능)

## 한계점
- FTSO가 제출할 가격을 조회하는 시점이 다소 빨라 -2 에폭의 delta값만 추출할 수 있습니다 (사진 첨부)
![image](https://github.com/user-attachments/assets/f117449b-e1c6-4e78-bb90-bef3713347b6)

## 특이사항
- 최신 main 브랜치를 pull 받아서 main 변경사항이 포함되어 있습니다